### PR TITLE
Allow *debugger-hook* fallback

### DIFF
--- a/test.lisp
+++ b/test.lisp
@@ -38,15 +38,16 @@
   (assert (test-invoke-debugger))
   t)
 
+(define-condition my-error (error) ())
+
 (defun test-error ()
   (labels ((debugger (condition hook)
              (declare (ignore hook))
              (when (and (null *debugger-hook*)
-                        (typep condition 'simple-error)
-                        (string= "Test 42" (princ-to-string condition)))
+                        (typep condition 'my-error))
                (return-from test-error t))))
     (trivial-custom-debugger:with-debugger (#'debugger)
-      (error "Test ~A" 42))))
+      (error 'my-error))))
 
 (defun test-break ()
   (labels ((debugger (condition hook)
@@ -67,17 +68,14 @@
                (return-from test-signal t))))
     (trivial-custom-debugger:with-debugger (#'debugger)
       (let ((*break-on-signals* 'error))
-        (signal 'simple-error)))))
+        (signal 'my-error)))))
 
 (defun test-invoke-debugger ()
   (labels ((debugger (condition hook)
              (declare (ignore hook))
              (when (and (null *debugger-hook*)
-                        (typep condition 'simple-error)
-                        (string= "Test 42" (princ-to-string condition)))
+                        (typep condition 'my-error))
                (return-from test-invoke-debugger t))))
     (trivial-custom-debugger:with-debugger (#'debugger)
       (let ((*break-on-signals* 'error))
-        (invoke-debugger (make-condition 'simple-error
-                                         :format-control "Test ~D"
-                                         :format-arguments '(42)))))))
+        (invoke-debugger (make-condition 'my-error))))))

--- a/trivial-custom-debugger.lisp
+++ b/trivial-custom-debugger.lisp
@@ -75,6 +75,8 @@
             #+allegro    excl::*break-hook*
             #+lispworks  dbg::*debugger-wrapper-list*
             #+mezzano    mezzano.debug:*global-debugger*
+            #-(or sbcl ccl ecl clasp abcl clisp allegro lispworks mezzano)
+                         *debugger-hook*
             (make-hook hook)))))
 
 (defun call-with-debugger (hook thunk)
@@ -88,7 +90,9 @@ provided hook function is set to be the system debugger."
         #+clisp      sys::*break-driver*
         #+allegro    excl::*break-hook*
         #+lispworks  dbg::*debugger-wrapper-list*
-        #+mezzano    mezzano.debug:*global-debugger*)
+        #+mezzano    mezzano.debug:*global-debugger*
+        #-(or sbcl ccl ecl clasp abcl clisp allegro lispworks mezzano)
+                     *debugger-hook*)
     (install-debugger hook)
     (funcall thunk)))
 


### PR DESCRIPTION
Some implementations like CMUCL use `*debugger-hook*` for BREAK so this is sufficient. Also using `princ-to-string` in the tests is unreliable for ERROR and INVOKE-DEBUGGER since the implementation's PRINT-OBJECT might insert extra stuff.